### PR TITLE
Fix missing env var for testnet

### DIFF
--- a/group_vars/testnet/berachain_bepolia.yml
+++ b/group_vars/testnet/berachain_bepolia.yml
@@ -2,8 +2,9 @@
 # Berachain Bepolia testnet
 #
 # Consensus container client & version
-consensus_version: v1.3.3 # Beacond release version
+consensus_version: v1.3.4 # Beacond release version
 consensus_chain_id: testnet-beacon-80069
+consensus_chain_spec: testnet
 
 # Consensus Engine Overrides
 # consensus_seeds: ""
@@ -11,7 +12,7 @@ consensus_chain_id: testnet-beacon-80069
 # suggested_fee_recipient: ""
 
 # Execution container client & version
-execution_container_version: v1.1.0
+execution_container_version: v1.3.1
 execution_client: reth # Available options: reth, geth
 execution_chain_id: 80069
 execution_genesis_md5sum: c27c1162af33f7f5401bcef974a64454 # eth-genesis updated 2025.09.15


### PR DESCRIPTION
Missing env var causes the beacond / consensus client to init with mainnet configs